### PR TITLE
Automatically draw barre chords based on fingering

### DIFF
--- a/lib/chord_diagrams.rb
+++ b/lib/chord_diagrams.rb
@@ -137,13 +137,13 @@ module ChordDiagrams
         last_string_index = (fingerings[fingerings.size - 1] != "x") ? fingerings.size - 1 : fingerings.size - 2
 
         if fingerings[first_string_index] != "x" &&
-          fingerings[first_string_index] == fingerings[last_string_index] &&
-          fingerings.all? { |f| f == "x" || fingerings[first_string_index].to_i <= f.to_i }
+            fingerings[first_string_index] == fingerings[last_string_index] &&
+            fingerings.all? { |f| f == "x" || fingerings[first_string_index].to_i <= f.to_i }
           svg.line x1: 50 + (20 * first_string_index),
-                   y1: 70 + (fingerings[first_string_index].to_i * 20),
-                   x2: 50 + (20 * last_string_index),
-                   y2: 70 + (fingerings[last_string_index].to_i * 20),
-                   style: { stroke: :black, stroke_width: 14 }
+            y1: 70 + (fingerings[first_string_index].to_i * 20),
+            x2: 50 + (20 * last_string_index),
+            y2: 70 + (fingerings[last_string_index].to_i * 20),
+            style: {stroke: :black, stroke_width: 14}
         end
       end
     end
@@ -182,7 +182,7 @@ module ChordDiagrams
     private
 
     def draw_fret_number(number, svg)
-      svg.text number, id: "fretNumber", x: 37, y: 98, text_anchor: :end, style: { font_size: 24 }
+      svg.text number, id: "fretNumber", x: 37, y: 98, text_anchor: :end, style: {font_size: 24}
     end
 
     def shift_guitar_fingerings(fingerings, lowest_fret)

--- a/lib/chord_diagrams.rb
+++ b/lib/chord_diagrams.rb
@@ -131,6 +131,21 @@ module ChordDiagrams
           draw_fingered_string(fingering, offset, svg)
         end
       end
+
+      unless fingerings.include?("0")
+        first_string_index = (fingerings[0] != "x") ? 0 : 1
+        last_string_index = (fingerings[fingerings.size - 1] != "x") ? fingerings.size - 1 : fingerings.size - 2
+
+        if fingerings[first_string_index] != "x" &&
+          fingerings[first_string_index] == fingerings[last_string_index] &&
+          fingerings.all? { |f| f == "x" || fingerings[first_string_index].to_i <= f.to_i }
+          svg.line x1: 50 + (20 * first_string_index),
+                   y1: 70 + (fingerings[first_string_index].to_i * 20),
+                   x2: 50 + (20 * last_string_index),
+                   y2: 70 + (fingerings[last_string_index].to_i * 20),
+                   style: { stroke: :black, stroke_width: 14 }
+        end
+      end
     end
 
     def draw_guitar_nut(svg)
@@ -148,7 +163,7 @@ module ChordDiagrams
     end
 
     def draw_fingered_string(fingering, offset, svg)
-      svg.circle cx: offset, cy: 70 + (fingering.to_i * 20), r: 8, style: {
+      svg.circle cx: offset, cy: 70 + (fingering.to_i * 20), r: 7, style: {
         fill: :black
       }
     end
@@ -167,7 +182,7 @@ module ChordDiagrams
     private
 
     def draw_fret_number(number, svg)
-      svg.text number, id: "fretNumber", x: 37, y: 98, text_anchor: :end, style: {font_size: 24}
+      svg.text number, id: "fretNumber", x: 37, y: 98, text_anchor: :end, style: { font_size: 24 }
     end
 
     def shift_guitar_fingerings(fingerings, lowest_fret)


### PR DESCRIPTION
We can determine most barre chords programmatically and render them as such.

There are a few chords the current logic doesn't capture (and they'd arguably be considered barre chords) but this is a good first step.

@stufro Would love to get your input on how these look.

## Screenshots

Note: click images to see diagrams at normal size

### Before

<img width="1602" alt="Screenshot 2023-08-10 at 4 16 29 PM" src="https://github.com/spilth/chord_diagrams/assets/13157/8940cb84-1ab2-4237-be71-c9eda0ef2f34">

<img width="1665" alt="Screenshot 2023-08-10 at 4 16 35 PM" src="https://github.com/spilth/chord_diagrams/assets/13157/26ed1619-cec8-48bc-8bde-41f01b717f44">


### After

<img width="1607" alt="Screenshot 2023-08-10 at 4 06 58 PM" src="https://github.com/spilth/chord_diagrams/assets/13157/ad8a6ca4-e156-407d-997a-f1197e15a92e">

<img width="1669" alt="Screenshot 2023-08-10 at 4 07 14 PM" src="https://github.com/spilth/chord_diagrams/assets/13157/5a7856f9-4721-4dc5-a355-3497d465a939">
